### PR TITLE
Fix inconsistent task field names

### DIFF
--- a/src/Components/AddTareaForm.jsx
+++ b/src/Components/AddTareaForm.jsx
@@ -23,18 +23,18 @@ const AddTareaForm = () => {
      // 1️⃣ Initialize form state with defaultValues and a submit handler
   const form = useForm({
     defaultValues: {
-      startdate: '',
-      enddate: '',
-      perincharge: '',
+      startDate: '',
+      endDate: '',
+      perInCharge: '',
       description: '',
-      Priority: '',
+      priority: '',
     },
     
 onSubmit: async ({ value }) => {
-  const { startdate, enddate } = value;
+  const { startDate, endDate } = value;
 
   // Validación manual directa
-  if (startdate && enddate && new Date(startdate) > new Date(enddate)) {
+  if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
     toast.error('La fecha de inicio no puede ser posterior a la fecha final.');
     return;
   }
@@ -84,14 +84,14 @@ onSubmit: async ({ value }) => {
       
         {/* ─── startDate Field ─────────────────────── */}
         <div className="flex flex-col">
-          <label htmlFor="startdate" className="mb-1 text-gray-700 font-medium">
+          <label htmlFor="startDate" className="mb-1 text-gray-700 font-medium">
             Fecha de inicio:
           </label>
-          <form.Field name="startdate">
+          <form.Field name="startDate">
             {field => (
               <input
-                id="startdate"
-                name="startdate"
+                id="startDate"
+                name="startDate"
                 type="date"
                 value={field.state.value}
                 onChange={e => field.handleChange(e.target.value)}
@@ -103,16 +103,16 @@ onSubmit: async ({ value }) => {
           </form.Field>
         </div>
       
-        {/* ─── enddate Field ────────────────────── */}
+        {/* ─── endDate Field ────────────────────── */}
         <div className="flex flex-col">
-          <label htmlFor="enddate" className="mb-1 text-gray-700 font-medium">
+          <label htmlFor="endDate" className="mb-1 text-gray-700 font-medium">
             Fecha final:
           </label>
-          <form.Field name="enddate">
+          <form.Field name="endDate">
             {field => (
               <input
-                id="enddate"
-                name="enddate"
+                id="endDate"
+                name="endDate"
                 type="date"
                 value={field.state.value}
                 onChange={e => field.handleChange(e.target.value)}
@@ -126,14 +126,14 @@ onSubmit: async ({ value }) => {
       
         {/* ─── Person in charge Field ─────────────────────── */}
         <div className="flex flex-col">
-          <label htmlFor="perincharge" className="mb-1 text-gray-700 font-medium">
+          <label htmlFor="perInCharge" className="mb-1 text-gray-700 font-medium">
             Persona a cargo:
           </label>
-          <form.Field name="perincharge">
+          <form.Field name="perInCharge">
             {field => (
               <input
-                id="perincharge"
-                name="perincharge"
+                id="perInCharge"
+                name="perInCharge"
                 value={field.state.value}
                 onChange={e => field.handleChange(e.target.value)}
                 onBlur={field.handleBlur}
@@ -147,14 +147,14 @@ onSubmit: async ({ value }) => {
         
       {/* ─── Priority Field ─────────────────────── */}
 <div className="flex flex-col">
-  <label htmlFor="Priority" className="mb-1 text-gray-700 font-medium">
+  <label htmlFor="priority" className="mb-1 text-gray-700 font-medium">
     Nivel de prioridad:
   </label>
-  <form.Field name="Priority">
+  <form.Field name="priority">
     {field => (
       <select
-        id="Priority"
-        name="Priority"
+        id="priority"
+        name="priority"
         value={field.state.value}
         onChange={e => field.handleChange(e.target.value)}
         onBlur={field.handleBlur}

--- a/src/Components/EditTareaForm.jsx
+++ b/src/Components/EditTareaForm.jsx
@@ -9,11 +9,11 @@ const EditTareaForm = ({ tarea, onSuccess }) => {
 
   const [formData, setFormData] = useState({
     id: tarea.id,
-  description: tarea.description,
-  startdate: tarea.startDate,
-  enddate: tarea.endDate,
-  perincharge: tarea.perInCharge,
-  Priority: tarea.priority
+    description: tarea.description,
+    startDate: tarea.startDate,
+    endDate: tarea.endDate,
+    perInCharge: tarea.perInCharge,
+    priority: tarea.priority
   });
 
   useEffect(() => {
@@ -35,25 +35,19 @@ const EditTareaForm = ({ tarea, onSuccess }) => {
   const handleSubmit = (e) => {
     e.preventDefault();
 
-if (formData.startdate > formData.enddate) {
-    toast.error("La fecha de inicio no puede ser despues de la fecha final.");
-    return;
-  }
-
+    if (formData.startDate > formData.endDate) {
+      toast.error("La fecha de inicio no puede ser despues de la fecha final.");
+      return;
+    }
 
     mutate(formData, {
       onSuccess: () => {
         toast.success("Tarea editada.");
-    if (onSuccess) onSuccess();
-    queryClient.invalidateQueries(['tareas']);
-  
-  
-  
-  
-  }
-    
-});
-  }
+        if (onSuccess) onSuccess();
+        queryClient.invalidateQueries(['tareas']);
+      },
+    });
+  };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
@@ -73,7 +67,7 @@ if (formData.startdate > formData.enddate) {
         <input
           type="date"
           name="startDate"
-          value={formData.startdate}
+          value={formData.startDate}
           onChange={handleChange}
           className="w-full border p-2 rounded"
           required
@@ -85,7 +79,7 @@ if (formData.startdate > formData.enddate) {
         <input
           type="date"
           name="endDate"
-          value={formData.enddate}
+          value={formData.endDate}
           onChange={handleChange}
           className="w-full border p-2 rounded"
           required
@@ -96,7 +90,7 @@ if (formData.startdate > formData.enddate) {
         <label className="block font-medium">Persona a cargo</label>
         <input
           name="perInCharge"
-          value={formData.perincharge}
+          value={formData.perInCharge}
           onChange={handleChange}
           className="w-full border p-2 rounded"
           required
@@ -107,7 +101,7 @@ if (formData.startdate > formData.enddate) {
         <label className="block font-medium">Nivel de prioridad</label>
         <select
           name="priority"
-          value={formData.Priority}
+          value={formData.priority}
           onChange={handleChange}
           className="w-full border p-2 rounded"
           required


### PR DESCRIPTION
## Summary
- standardize task form field names to match backend data
- clean up handleSubmit logic in edit task form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859d94913d083239f1f3e7ef2f1c35f