### PR TITLE
Standardize CRUD form styling

### DIFF
--- a/src/Components/AddTareaForm.jsx
+++ b/src/Components/AddTareaForm.jsx
@@ -74,7 +74,7 @@ onSubmit: async ({ value }) => {
                 value={field.state.value}
                 onChange={e => field.handleChange(e.target.value)}
                 onBlur={field.handleBlur}
-                className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="border border-teal-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-teal-600"
                 required
               />
             )}
@@ -96,7 +96,7 @@ onSubmit: async ({ value }) => {
                 value={field.state.value}
                 onChange={e => field.handleChange(e.target.value)}
                 onBlur={field.handleBlur}
-                className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="border border-teal-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-teal-600"
                 required
               />
             )}
@@ -117,7 +117,7 @@ onSubmit: async ({ value }) => {
                 value={field.state.value}
                 onChange={e => field.handleChange(e.target.value)}
                 onBlur={field.handleBlur}
-                className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="border border-teal-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-teal-600"
                 required
               />
             )}
@@ -137,7 +137,7 @@ onSubmit: async ({ value }) => {
                 value={field.state.value}
                 onChange={e => field.handleChange(e.target.value)}
                 onBlur={field.handleBlur}
-                className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="border border-teal-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-teal-600"
                 required
               />
             )}
@@ -158,7 +158,7 @@ onSubmit: async ({ value }) => {
         value={field.state.value}
         onChange={e => field.handleChange(e.target.value)}
         onBlur={field.handleBlur}
-        className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="border border-teal-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-teal-600"
         required
       >
         <option value="">Selecciona una prioridad</option>

--- a/src/Components/EditTareaForm.jsx
+++ b/src/Components/EditTareaForm.jsx
@@ -57,7 +57,7 @@ const EditTareaForm = ({ tarea, onSuccess }) => {
           name="description"
           value={formData.description}
           onChange={handleChange}
-          className="w-full border p-2 rounded"
+          className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
           required
         />
       </div>
@@ -69,7 +69,7 @@ const EditTareaForm = ({ tarea, onSuccess }) => {
           name="startDate"
           value={formData.startDate}
           onChange={handleChange}
-          className="w-full border p-2 rounded"
+          className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
           required
         />
       </div>
@@ -81,7 +81,7 @@ const EditTareaForm = ({ tarea, onSuccess }) => {
           name="endDate"
           value={formData.endDate}
           onChange={handleChange}
-          className="w-full border p-2 rounded"
+          className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
           required
         />
       </div>
@@ -92,7 +92,7 @@ const EditTareaForm = ({ tarea, onSuccess }) => {
           name="perInCharge"
           value={formData.perInCharge}
           onChange={handleChange}
-          className="w-full border p-2 rounded"
+          className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
           required
         />
       </div>
@@ -103,7 +103,7 @@ const EditTareaForm = ({ tarea, onSuccess }) => {
           name="priority"
           value={formData.priority}
           onChange={handleChange}
-          className="w-full border p-2 rounded"
+          className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
           required
         >
           <option value="">Seleccione</option>

--- a/src/Components/Modals/AddGenericModal.jsx
+++ b/src/Components/Modals/AddGenericModal.jsx
@@ -16,22 +16,22 @@ const AddGenericModal = ({ show, isOpen, onClose, title, children, size = "md" }
     // backdrop
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 overflow-auto">
       {/* panel */}
-      <div
-        className={`relative bg-white rounded-lg shadow-lg w-full ${sizeClass} mx-4 my-8 p-6`}
-      >
-        {/* close button */}
-        <button
-          onClick={onClose}
-          className="absolute top-3 right-3 text-gray-500 hover:text-gray-800 text-2xl leading-none"
-        >
-          &times;
-        </button>
+      <div className={`bg-gradient-to-r from-teal-900 to-teal-600 p-1 rounded-xl w-full ${sizeClass} mx-4 my-8`}>
+        <div className="relative bg-white rounded-lg shadow-lg p-6">
+          {/* close button */}
+          <button
+            onClick={onClose}
+            className="absolute top-3 right-3 text-gray-500 hover:text-gray-800 text-2xl leading-none"
+          >
+            &times;
+          </button>
 
-        {/* optional title */}
-        {title && <h2 className="mb-4 text-xl font-semibold">{title}</h2>}
+          {/* optional title */}
+          {title && <h2 className="mb-4 text-xl font-semibold">{title}</h2>}
 
-        {/* whatever you pass in */}
-        <div className="max-h-[80vh] overflow-y-auto">{children}</div>
+          {/* whatever you pass in */}
+          <div className="max-h-[80vh] overflow-y-auto">{children}</div>
+        </div>
       </div>
     </div>
   );

--- a/src/Pages/InventarioPage.jsx
+++ b/src/Pages/InventarioPage.jsx
@@ -144,7 +144,7 @@ function InventarioPage() {
               placeholder="Buscar en el inventario..."
               value={filtro}
               onChange={(e) => setFiltro(e.target.value)}
-              className="border border-gray-300 px-3 py-2 rounded w-64"
+              className="border border-teal-700 px-3 py-2 rounded w-64 focus:outline-none focus:ring-2 focus:ring-teal-600"
             />
             <button
               onClick={() => {
@@ -162,10 +162,11 @@ function InventarioPage() {
 
           {showModal && (
             <div className="fixed inset-0 backdrop-blur-sm bg-white/30 flex items-center justify-center z-50 overflow-auto">
-              <div className="bg-white p-6 rounded shadow-lg w-full max-w-sm sm:max-w-md md:max-w-lg max-h-screen overflow-y-auto mx-4 my-8">
-                <h2 className="text-xl font-semibold mb-4">
-                  {itemEditando ? 'Editar Artículo' : 'Agregar Artículo'}
-                </h2>
+              <div className="bg-gradient-to-r from-teal-900 to-teal-600 p-1 rounded-xl w-full max-w-sm sm:max-w-md md:max-w-lg mx-4 my-8">
+                <div className="bg-white p-6 rounded shadow-lg max-h-screen overflow-y-auto">
+                  <h2 className="text-xl font-semibold mb-4">
+                    {itemEditando ? 'Editar Artículo' : 'Agregar Artículo'}
+                  </h2>
                 <form onSubmit={guardar} className="space-y-4">
                   <div>
                     <label className="block font-medium">Nombre</label>
@@ -174,7 +175,7 @@ function InventarioPage() {
                      name="nombre"
                      value={nombreInput}
                      onChange={handleNombreChange}
-                     className="w-full border border-gray-300 px-3 py-2 rounded"
+                     className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                      />
                   </div>
                   <div>
@@ -183,7 +184,7 @@ function InventarioPage() {
                       type="text"
                       name="descripcion"
                       defaultValue={itemEditando?.descripcion || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                     />
                   </div>
                   <div>
@@ -192,7 +193,7 @@ function InventarioPage() {
                       type="number"
                       name="cantidad"
                       defaultValue={itemEditando?.cantidad || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                       min="0"
                       step="1"
                     />
@@ -202,7 +203,7 @@ function InventarioPage() {
                      <select
                      name="unidad"
                       defaultValue={itemEditando?.unidad || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                      required
                      >
                       <option value="" disabled>Seleccione una unidad...</option>
@@ -221,7 +222,7 @@ function InventarioPage() {
                       type="date"
                       name="fechaIngreso"
                       defaultValue={itemEditando?.fechaIngreso?.slice(0, 10) || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                     />
                   </div>
                  <div>
@@ -231,14 +232,14 @@ function InventarioPage() {
                     type="number"
                     name="precio"
                     defaultValue={itemEditando?.precio || ''}
-                    className="flex-1 border border-gray-300 px-3 py-2 rounded"
+                    className="flex-1 border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                    min="0"
                    step="0.01"
                  />
                   <select
                   name="moneda"
                  defaultValue={itemEditando?.moneda || '₡'}
-                 className="border border-gray-300 px-2 py-2 rounded"
+                 className="border border-teal-700 px-2 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                  >
                  <option value="₡">₡</option>
                   <option value="$">$</option>
@@ -253,7 +254,7 @@ function InventarioPage() {
                       type="text"
                       name="categoria"
                       defaultValue={itemEditando?.categoria || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                     />
                   </div>
 
@@ -273,6 +274,7 @@ function InventarioPage() {
                     </button>
                   </div>
                 </form>
+              </div>
               </div>
             </div>
           )}

--- a/src/Pages/ProveedoresPage.jsx
+++ b/src/Pages/ProveedoresPage.jsx
@@ -114,7 +114,7 @@ function ProveedoresPage() {
               placeholder="Buscar proveedores..."
               value={filtro}
               onChange={(e) => setFiltro(e.target.value)}
-              className="border border-gray-300 px-3 py-2 rounded w-64"
+              className="border border-teal-700 px-3 py-2 rounded w-64 focus:outline-none focus:ring-2 focus:ring-teal-600"
             />
             <button
               onClick={() => {
@@ -131,18 +131,19 @@ function ProveedoresPage() {
 
           {showModal && (
             <div className="fixed inset-0 backdrop-blur-sm bg-white/30 flex items-center justify-center z-50 overflow-auto">
-              <div className="bg-white p-6 rounded shadow-lg w-full max-w-sm sm:max-w-md md:max-w-lg max-h-screen overflow-y-auto mx-4 my-8">
-                <h2 className="text-xl font-semibold mb-4">
-                  {proveedorEditando ? 'Editar Proveedor' : 'Agregar Proveedor'}
-                </h2>
-                <form onSubmit={guardar} className="space-y-4">
+              <div className="bg-gradient-to-r from-teal-900 to-teal-600 p-1 rounded-xl w-full max-w-sm sm:max-w-md md:max-w-lg mx-4 my-8">
+                <div className="bg-white p-6 rounded shadow-lg max-h-screen overflow-y-auto">
+                  <h2 className="text-xl font-semibold mb-4">
+                    {proveedorEditando ? 'Editar Proveedor' : 'Agregar Proveedor'}
+                  </h2>
+                  <form onSubmit={guardar} className="space-y-4">
                   <div>
                     <label className="block font-medium">Nombre de la Empresa</label>
                     <input
                       type="text"
                       name="nombreEmpresa"
                       defaultValue={proveedorEditando?.nombreEmpresa || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                       required
                     />
                   </div>
@@ -154,7 +155,7 @@ function ProveedoresPage() {
                       pattern="^[^\d]+$"
                       title="No se permiten números"
                       defaultValue={proveedorEditando?.nombreRepresentante || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                       required
                     />
                   </div>
@@ -166,7 +167,7 @@ function ProveedoresPage() {
                       pattern="\d+"
                       title="Solo se permiten números"
                       defaultValue={proveedorEditando?.cedulaRepresentante || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                       required
                     />
                   </div>
@@ -176,7 +177,7 @@ function ProveedoresPage() {
                       type="email"
                       name="correoEmpresa"
                       defaultValue={proveedorEditando?.correoEmpresa || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                       required
                     />
                   </div>
@@ -188,7 +189,7 @@ function ProveedoresPage() {
                       pattern="\d+"
                       title="Solo se permiten números"
                       defaultValue={proveedorEditando?.telefonoEmpresa || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                       required
                     />
                   </div>
@@ -198,7 +199,7 @@ function ProveedoresPage() {
                       type="text"
                       name="descripcionProductos"
                       defaultValue={proveedorEditando?.descripcionProductos || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                       required
                     />
                   </div>
@@ -208,7 +209,7 @@ function ProveedoresPage() {
                       type="text"
                       name="numeroCuenta"
                       defaultValue={proveedorEditando?.numeroCuenta || ''}
-                      className="w-full border border-gray-300 px-3 py-2 rounded"
+                      className="w-full border border-teal-700 px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-teal-600"
                       required
                     />
                   </div>
@@ -229,6 +230,7 @@ function ProveedoresPage() {
                     </button>
                   </div>
                 </form>
+              </div>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- refine text input styling in AddTareaForm and EditTareaForm
- apply uniform modal container style in AddGenericModal
- harmonize provider and inventory modals with new style and update input classes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859e108b624832380933815fdf46913