### PR TITLE
Fix API port usage

### DIFF
--- a/src/Services/AuthService.js
+++ b/src/Services/AuthService.js
@@ -3,7 +3,7 @@ import { jwtDecode } from "jwt-decode";
 
 
 export const client = axios.create({
-  baseURL: 'https://localhost:7255',
+  baseURL: 'http://localhost:5067',
   headers: {
     'Content-Type': 'application/json'
   },

--- a/src/Services/InventarioService.js
+++ b/src/Services/InventarioService.js
@@ -1,7 +1,7 @@
 
 import axios from 'axios';
 
-const BASE_URL = "https://localhost:7255/api/Inventario";
+const BASE_URL = "http://localhost:5067/api/Inventario";
 
 // Función para obtener headers con token
 const getAuthHeaders = () => {

--- a/src/Services/ProveedoresService.js
+++ b/src/Services/ProveedoresService.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const API_KEY = import.meta.env.VITE_MASTER_KEY_Proveedores;
-const BASE_URL = "https://localhost:7255/api/Proveedores";
+const BASE_URL = "http://localhost:5067/api/Proveedores";
 const headers = {
   'Content-Type': 'application/json',
   'X-Master-Key': API_KEY,

--- a/src/Services/ReportService.js
+++ b/src/Services/ReportService.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
-const BASE_URL = "https://localhost:7255/api/Reportes"; 
+const BASE_URL = "http://localhost:5067/api/Reportes";
 
 export const fetchReportes = async () => {
   const res = await axios.get(BASE_URL);

--- a/src/Services/TareasServices.js
+++ b/src/Services/TareasServices.js
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { jwtDecode } from "jwt-decode";
 
-const BASE_URL = "https://localhost:7255/api/Tareas";
+const BASE_URL = "http://localhost:5067/api/Tareas";
 
 export const useObtenerTareas = () => {
   return useQuery({

--- a/src/Services/UsersService.js
+++ b/src/Services/UsersService.js
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
-const BASE_URL = 'https://localhost:7255/api/Users';
+const BASE_URL = 'http://localhost:5067/api/Users';
 
 // Función para obtener headers con el token JWT
 const getAuthHeaders = () => {


### PR DESCRIPTION
## Summary
- point client services to http://localhost:5067

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685b3375e744832398991eb910a62693